### PR TITLE
Improve PDF background customization

### DIFF
--- a/pdf_design_options.py
+++ b/pdf_design_options.py
@@ -1,0 +1,17 @@
+"""PDF design utility functions and presets."""
+import base64
+from pathlib import Path
+from typing import Dict, Optional
+
+BACKGROUND_PRESETS: Dict[str, Dict[str, Optional[str]]] = {
+    "light_gray": {"color": "#F8F9FA", "image": None},
+    "solar_blue": {"color": "#E5EEF8", "image": None},
+}
+
+def load_background_image_base64(path: str) -> Optional[str]:
+    """Load an image file and return a base64 encoded string."""
+    try:
+        data = Path(path).read_bytes()
+        return base64.b64encode(data).decode("ascii")
+    except Exception:
+        return None


### PR DESCRIPTION
## Summary
- add `pdf_design_options` with simple presets and helper
- enhance `pdf_generator` page layout handler to support background color or image
- pass new background options through layout callback

## Testing
- `pytest -q test_pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_687d288c2df0832ea79cd4070fdd4a01

## Summary by Sourcery

Enable PDF background customization by introducing design presets and enhancing the layout handler to apply background colors or images.

New Features:
- Add pdf_design_options module with background color presets and base64 image loader
- Extend page_layout_handler to draw optional background color or image on each PDF page
- Pass background_color and background_image options into the PDF generation callback