### PR TITLE
Add visualizations for additional technical metrics

### DIFF
--- a/doc_output.py
+++ b/doc_output.py
@@ -347,6 +347,9 @@ def render_pdf_ui(
                     'yearly_production_chart_bytes': get_text_pdf_ui(texts, "pdf_chart_label_pvvis_yearly", "PV Visuals: Jahresproduktion"),
                     'break_even_chart_bytes': get_text_pdf_ui(texts, "pdf_chart_label_pvvis_breakeven", "PV Visuals: Break-Even"),
                     'amortisation_chart_bytes': get_text_pdf_ui(texts, "pdf_chart_label_pvvis_amort", "PV Visuals: Amortisation"),
+                    'degradation_chart_bytes': get_text_pdf_ui(texts, "pdf_chart_label_degradation", "Moduldegradation"),
+                    'battery_cycles_chart_bytes': get_text_pdf_ui(texts, "pdf_chart_label_battery_cycles", "Batteriezyklen"),
+                    'energy_independence_chart_bytes': get_text_pdf_ui(texts, "pdf_chart_label_energy_independence", "Entwicklung Autarkie"),
                 }
                 available_chart_keys = [k for k in analysis_results.keys() if k.endswith('_chart_bytes') and analysis_results[k] is not None]
                 ordered_display_keys = [k_map for k_map in chart_key_to_friendly_name_map.keys() if k_map in available_chart_keys]

--- a/pdf_generator.py
+++ b/pdf_generator.py
@@ -1506,6 +1506,9 @@ def generate_offer_pdf(
                         'yearly_production_chart_bytes': {"title_key": "pdf_chart_label_pvvis_yearly", "default_title": "PV Visuals: Jahresproduktion"},
                         'break_even_chart_bytes': {"title_key": "pdf_chart_label_pvvis_breakeven", "default_title": "PV Visuals: Break-Even"},
                         'amortisation_chart_bytes': {"title_key": "pdf_chart_label_pvvis_amort", "default_title": "PV Visuals: Amortisation"},
+                        'degradation_chart_bytes': {"title_key": "pdf_chart_label_degradation", "default_title": "Moduldegradation"},
+                        'battery_cycles_chart_bytes': {"title_key": "pdf_chart_label_battery_cycles", "default_title": "Batteriezyklen"},
+                        'energy_independence_chart_bytes': {"title_key": "pdf_chart_label_energy_independence", "default_title": "Entwicklung Autarkie"},
                     }
                     charts_added_count = 0
                     selected_charts_for_pdf_opt = inclusion_options.get("selected_charts_for_pdf", [])


### PR DESCRIPTION
## Summary
- expose new `render_technical_calculations` to visualize extra calculations
- store degradation, battery and independence charts for PDF export
- extend PDF selection UI to include the new charts
- update PDF generator mapping so charts can be embedded

## Testing
- `pytest -k analysis -q` *(fails: SystemExit)*

------
https://chatgpt.com/codex/tasks/task_e_687d26ed09dc832e99ba375326d64eeb